### PR TITLE
Changed requirements for images in OPDS 2.0

### DIFF
--- a/opds-2.0.md
+++ b/opds-2.0.md
@@ -128,7 +128,7 @@ Publications <em class="rfc">must</em> either be:
 - a [Readium Web Publication](https://github.com/readium/webpub-manifest) with no restrictions in terms of access (no payment, no credentials required, no limitations whatsoever)
 - or an [OPDS Publication](#41-opds-publication)   
 
-Each publication listed in an OPDS feed <em class="rfc">must</em> contain an `images` collection.
+Each publication listed in an OPDS feed <em class="rfc">should</em> contain an `images` collection.
 
 **Example**
 

--- a/opds-2.0.md
+++ b/opds-2.0.md
@@ -174,7 +174,7 @@ This new collection role is mostly meant to support responsive images across all
 
 Link Objects in `images` <em class="rfc">may</em> include any number of image format, resolution or aspect ratio.
 
-At least one image resource <em class="rfc">must</em> use one of the following formats: `image/jpeg`, `image/png` or `image/gif`.
+At least one image resource <em class="rfc">must</em> use one of the following formats: `image/jpeg`, `image/avif`, `image/png` or `image/gif`.
 
 **Example**
 

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -58,12 +58,13 @@
       "minItems": 1,
       "allOf": [
         {
-          "description": "At least one image resource must use one of the following formats: image/jpeg, image/png or image/gif.",
+          "description": "At least one image resource must use one of the following formats: image/jpeg, image/avif, image/png or image/gif.",
           "contains": {
             "properties": {
               "type": {
                 "enum": [
                   "image/jpeg",
+                  "image/avif",
                   "image/png",
                   "image/gif"
                 ]

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -76,7 +76,6 @@
   },
   "required": [
     "metadata",
-    "links",
-    "images"
+    "links"
   ]
 }


### PR DESCRIPTION
Based on @llemeurfr initial comment on #52 :

- Lowered the requirement for images in publication to a SHOULD 
- Dropped requirement from the JSON Schema
- Added AVIF support in spec and JSON Schema